### PR TITLE
Remove ADTL from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ Documentation: [ReadTheDocs](https://insightboard.readthedocs.io/en/latest)
 
 ## Installation
 
-Install using your favourite package manager. It is recommended to install into a virtual environment. We recommend using [uv](https://github.com/astral-sh/uv) to manage the virtual environment.
-
+Install **Insight**Board using your favourite package manager. For `pip` this would be:
 ```bash
-uv sync
-. .venv/bin/activate
+pip install InsightBoard
+```
+
+You will also want to install ADTL (Another Data Transform Language) to make full use of the parsers, including those supplied with the sample project:
+```bash
+pip install "adtl[parquet] @ git+https://github.com/globaldothealth/adtl"
 ```
 
 To launch the dashboard, simply type `InsightBoard` from the command line. The dashboard should appear in your default web browser. By default the dashboard will be available at http://localhost:8050/.
@@ -35,4 +38,11 @@ Details of how to create a new project are provided in the accompanying [documen
 
 ## Development
 
-To launch the dashboard in development mode, follow the [Installation](#installation) instructions but instead launch with `python -m InsightBoard`.
+If you have cloned the repository, it is recommended to install into a virtual environment. We use [uv](https://docs.astral.sh/uv/) to manage virtual environments. First, [install `uv`](https://docs.astral.sh/uv/getting-started/installation/), then activate the virtual environment:
+
+```bash
+uv sync
+. .venv/bin/activate
+```
+
+To launch the dashboard in development mode run `python -m InsightBoard`.

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -8,10 +8,16 @@ InsightBoard is a Python application that runs through your web browser. You can
 pip install InsightBoard
 ```
 
+````{note}
+You will also need to install `ADTL` (Another Data Transform Language) to make full use of the parsers, including those supplied with the `sample_project`:
+```bash
+pip install "adtl[parquet] @ git+https://github.com/globaldothealth/adtl"
+```
+````
+
 Note that it is usually recommended to install into a virtual environment. We recommend using [uv](https://github.com/astral-sh/uv) to manage the virtual environment. To create and active a virtual environment for InsightBoard using `uv` run the following commands:
 
 ```bash
-uv venv
 uv sync
 . .venv/bin/activate
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "gunicorn>=23.0.0",
     "pyarrow>=17.0.0",
     "openpyxl>=3.1.5",
-    "adtl[parquet]>=0.6.0",
     "jsonschema>=4.23.0",
     "dash-dangerously-set-inner-html>=0.0.2",
     "tomli-w>=1.0.0",
@@ -32,6 +31,3 @@ package = true
 dev-dependencies = [
     "pytest>=8.3.3",
 ]
-
-[tool.uv.sources]
-adtl = { git = "https://github.com/globaldothealth/adtl" }

--- a/src/InsightBoard/pages/upload.py
+++ b/src/InsightBoard/pages/upload.py
@@ -28,7 +28,7 @@ def layout():
             dcc.Store(id="show-full-validation-log"),  # Setting: Show full log
             # Page rendering
             html.H1("Upload data"),
-            dcc.Location(id='url-refresh', refresh=True),
+            dcc.Location(id="url-refresh", refresh=True),
             html.Div(id="output-upload-data"),
             html.Div(
                 [
@@ -584,7 +584,9 @@ def parse_file(
     trig_update_btn = ctx_trigger(ctx, "update-button.n_clicks")
     # Parse the data (read from files)
     if trig_parse_btn:
-        msg, parsed_data_store, *rtn = parse_data(project, contents, filename, selected_parser)
+        msg, parsed_data_store, *rtn = parse_data(
+            project, contents, filename, selected_parser
+        )
         if parsed_data_store:
             # Update the table dropdown
             return (

--- a/src/InsightBoard/parsers/__init__.py
+++ b/src/InsightBoard/parsers/__init__.py
@@ -1,7 +1,28 @@
-import adtl as adtl_parser
+import shutil
 import subprocess
 import pandas as pd
 from tempfile import NamedTemporaryFile
+
+try:
+    import adtl as adtl_parser
+except ImportError:
+    adtl_parser = None
+
+
+def adtl_check_command():
+    if shutil.which("adtl") is None:
+        raise ImportError(
+            "ADTL is not installed. Please install it using `pip install "
+            '"adtl[parquet] @ git+https://github.com/globaldothealth/adtl"`'
+        )
+
+
+def adtl_check_parser():
+    if adtl_parser is None:
+        raise ImportError(
+            "ADTL is not installed. Please install it using `pip install "
+            '"adtl[parquet] @ git+https://github.com/globaldothealth/adtl"`'
+        )
 
 
 def adtl(df: pd.DataFrame, specification: str, *cl_args) -> dict:
@@ -12,6 +33,7 @@ def adtl(df: pd.DataFrame, specification: str, *cl_args) -> dict:
         specification: Path to ADTL specification file
         *cl_args: List of additional command-line arguments to pass to ADTL
     """
+    adtl_check_command()
     # Write pandas dataframe to temp file, then run adtl
     with NamedTemporaryFile(suffix=".csv") as input_csv:
         df.to_csv(input_csv.name, index=False)
@@ -23,6 +45,7 @@ def adtl(df: pd.DataFrame, specification: str, *cl_args) -> dict:
 
 
 def parse_adtl(df: pd.DataFrame, spec_file, table_names) -> list[dict]:
+    adtl_check_parser()
     if isinstance(table_names, str):
         table_names = [table_names]
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,34 +7,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "adtl"
-version = "0.6.0"
-source = { git = "https://github.com/globaldothealth/adtl#8e4c96dbe457cc47cac913a0d9b0738c37b85a40" }
-dependencies = [
-    { name = "fastjsonschema" },
-    { name = "more-itertools" },
-    { name = "pint" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-    { name = "tomli" },
-    { name = "tqdm" },
-]
-
-[package.optional-dependencies]
-parquet = [
-    { name = "polars" },
-]
-
-[[package]]
-name = "appdirs"
-version = "1.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566 },
-]
-
-[[package]]
 name = "attrs"
 version = "24.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -199,15 +171,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fastjsonschema"
-version = "2.16.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/70/0b49eee4a6aef4b67699e65fe8b8f4a3a25d39971bcd6f1c930a91141f3b/fastjsonschema-2.16.3.tar.gz", hash = "sha256:4a30d6315a68c253cfa8f963b9697246315aa3db89f98b97235e345dedfb0b8e", size = 19081 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/e7/84b1571b866b8abd604f8b72234d16f01bd5944014ef9929b5cb0da198c1/fastjsonschema-2.16.3-py3-none-any.whl", hash = "sha256:04fbecc94300436f628517b05741b7ea009506ce8f946d40996567c669318490", size = 23190 },
-]
-
-[[package]]
 name = "flask"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -221,30 +184,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/e1/d104c83026f8d35dfd2c261df7d64738341067526406b40190bc063e829a/flask-3.0.3.tar.gz", hash = "sha256:ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842", size = 676315 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/80/ffe1da13ad9300f87c93af113edd0638c75138c42a0994becfacac078c06/flask-3.0.3-py3-none-any.whl", hash = "sha256:34e815dfaa43340d1d15a5c3a02b8476004037eb4840b34910c6e21679d288f3", size = 101735 },
-]
-
-[[package]]
-name = "flexcache"
-version = "0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/b0/8a21e330561c65653d010ef112bf38f60890051d244ede197ddaa08e50c1/flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656", size = 15816 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32", size = 13263 },
-]
-
-[[package]]
-name = "flexparser"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/e4/a73612499d9c8c450c8f4878e8bb8b3b2dce4bf671b21dd8d5c6549525a7/flexparser-0.3.1.tar.gz", hash = "sha256:36f795d82e50f5c9ae2fde1c33f21f88922fdd67b7629550a3cc4d0b40a66856", size = 31422 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/28/5ce78a4838bb9da1bd9f64bc79ba12ddbfcb4824a11ef41da6f05d3240ef/flexparser-0.3.1-py3-none-any.whl", hash = "sha256:2e3e2936bec1f9277f777ef77297522087d96adb09624d4fe4240fd56885c013", size = 27289 },
 ]
 
 [[package]]
@@ -291,10 +230,9 @@ wheels = [
 
 [[package]]
 name = "insightboard"
-version = "0.1.0"
+version = "0.0.1.dev42+ge609414.d20241004"
 source = { editable = "." }
 dependencies = [
-    { name = "adtl", extra = ["parquet"] },
     { name = "dash" },
     { name = "dash-bootstrap-components" },
     { name = "dash-dangerously-set-inner-html" },
@@ -314,7 +252,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adtl", extras = ["parquet"], git = "https://github.com/globaldothealth/adtl" },
     { name = "dash", specifier = ">=2.18.1" },
     { name = "dash-bootstrap-components", specifier = ">=1.6.0" },
     { name = "dash-dangerously-set-inner-html", specifier = ">=0.0.2" },
@@ -404,15 +341,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/07/2dc76aa51b481eb96a4c3198894f38b480490e834479611a4053fbf08623/MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169", size = 33038 },
     { url = "https://files.pythonhosted.org/packages/96/0c/620c1fb3661858c0e37eb3cbffd8c6f732a67cd97296f725789679801b31/MarkupSafe-2.1.5-cp312-cp312-win32.whl", hash = "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad", size = 16572 },
     { url = "https://files.pythonhosted.org/packages/3f/14/c3554d512d5f9100a95e737502f4a2323a1959f6d0d01e0d0997b35f7b10/MarkupSafe-2.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb", size = 17127 },
-]
-
-[[package]]
-name = "more-itertools"
-version = "10.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/78/65922308c4248e0eb08ebcbe67c95d48615cc6f27854b6f2e57143e9178f/more-itertools-10.5.0.tar.gz", hash = "sha256:5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6", size = 121020 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/7e/3a64597054a70f7c86eb0a7d4fc315b8c1ab932f64883a297bdffeb5f967/more_itertools-10.5.0-py3-none-any.whl", hash = "sha256:037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef", size = 60952 },
 ]
 
 [[package]]
@@ -533,21 +461,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pint"
-version = "0.24.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "appdirs" },
-    { name = "flexcache" },
-    { name = "flexparser" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/7d/30178ff193a076e35521592260915f74049bfa77dccb43ac8aa5abe1414b/pint-0.24.3.tar.gz", hash = "sha256:d54771093e8b94c4e0a35ac638c2444ddf3ef685652bab7675ffecfa0c5c5cdf", size = 341664 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/2b/abe15c62ef1aece41d0799f31ba97d298aad9c76bc31dd655c387c29f17a/Pint-0.24.3-py3-none-any.whl", hash = "sha256:d98667e46fd03a1b94694fbfa104ec30858684d8ab26952e2a348b48059089bb", size = 301758 },
-]
-
-[[package]]
 name = "plotly"
 version = "5.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -567,19 +480,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
-]
-
-[[package]]
-name = "polars"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/09/c2fb0b231d551e0c8e68097d08577712bdff1ba91346cda8228e769602f5/polars-1.9.0.tar.gz", hash = "sha256:8e1206ef876f61c1d50a81e102611ea92ee34631cb135b46ad314bfefd3cb122", size = 4027431 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/cc/3d0292048d8f9045a03510aeecda2e6ed9df451ae8853274946ff841f98b/polars-1.9.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a471d2ce96f6fa5dd0ef16bcdb227f3dbe3af8acb776ca52f9e64ef40c7489a0", size = 31870933 },
-    { url = "https://files.pythonhosted.org/packages/ee/be/15af97f4d8b775630da16a8bf0141507d9c0ae5f2637b9a27ed337b3b1ba/polars-1.9.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94b12d731cd200d2c50b13fc070d6353f708e632bca6529c5a72aa6a69e5285d", size = 28171055 },
-    { url = "https://files.pythonhosted.org/packages/bb/57/b286b317f061d8f17bab4726a27e7b185fbf3d3db65cf689074256ea34a9/polars-1.9.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f85f132732aa63c6f3b502b0fdfc3ba9f0b78cc6330059b5a2d6f9fd78508acb", size = 33063367 },
-    { url = "https://files.pythonhosted.org/packages/e5/25/bf5d43dcb538bf6573b15f3d5995a52be61b8fbce0cd737e72c4d25eef88/polars-1.9.0-cp38-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:f753c8941a3b3249d59262d68a856714a96a7d4e16977aefbb196be0c192e151", size = 29764698 },
-    { url = "https://files.pythonhosted.org/packages/a6/cf/f9170a3ac20e0efb9d3c1cdacc677e35b711ffd5ec48a6d5f3da7b7d8663/polars-1.9.0-cp38-abi3-win_amd64.whl", hash = "sha256:95de07066cd797dd940fa2783708a7bef93c827a57be0f4dfad3575a6144212b", size = 32819142 },
 ]
 
 [[package]]
@@ -758,33 +658,12 @@ wheels = [
 ]
 
 [[package]]
-name = "tomli"
-version = "2.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/b9/de2a5c0144d7d75a57ff355c0c24054f965b2dc3036456ae03a51ea6264b/tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed", size = 16096 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38", size = 13237 },
-]
-
-[[package]]
 name = "tomli-w"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/05/6bf21838623186b91aedbda06248ad18f03487dc56fbc20e4db384abde6c/tomli_w-1.0.0.tar.gz", hash = "sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9", size = 6531 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/01/1da9c66ecb20f31ed5aa5316a957e0b1a5e786a0d9689616ece4ceaf1321/tomli_w-1.0.0-py3-none-any.whl", hash = "sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463", size = 5984 },
-]
-
-[[package]]
-name = "tqdm"
-version = "4.66.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/58/83/6ba9844a41128c62e810fddddd72473201f3eacde02046066142a2d96cc5/tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad", size = 169504 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/5d/acf5905c36149bbaec41ccf7f2b68814647347b72075ac0b1fe3022fdc73/tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd", size = 78351 },
 ]
 
 [[package]]


### PR DESCRIPTION
ADTL is hosted in a github repository. These dependencies are not installable via PyPI. We have therefore removed ADTL from the project dependencies and made a note to the user to install ADTL separately (at least until adtl is available from PyPI).