### PR TITLE
Preserve NA to None prior to schema validation

### DIFF
--- a/src/InsightBoard/pages/upload.py
+++ b/src/InsightBoard/pages/upload.py
@@ -1,3 +1,4 @@
+import math
 import dash
 import pandas as pd
 import dash_bootstrap_components as dbc
@@ -333,15 +334,18 @@ def clean_value(x, key_name=None, dtypes={}):
     if "number" in target_types and isinstance(x, str):
         try:
             if "." in x:
-                return float(x)
+                n = float(x)
+                if math.isnan(n):
+                    return None
             else:
-                return int(x)
+                n = int(x)
+            return n
         except Exception:
             pass
 
     if "integer" in target_types and isinstance(x, str):
         try:
-            return int(x)
+            return int(x)  # int cannot be nan
         except Exception:
             pass
 
@@ -490,6 +494,7 @@ def validate_errors(
         schema_file_strict = None
 
     # Validate the data against the schema
+    df = df.where(pd.notnull(df), None)
     errors = errors_to_dict(utils.validate_against_jsonschema(df, schema_file_relaxed))
 
     # If a strict schema exists, validate against that too

--- a/src/InsightBoard/utils.py
+++ b/src/InsightBoard/utils.py
@@ -40,7 +40,12 @@ def validate_against_jsonschema(df: pd.DataFrame, schema):
     # schema validation
     error_list = []
     for idx, row in df.iterrows():
-        errors = validate_row_jsonschema(idx, row.to_dict(), schema)
+        row_dict = row.to_dict()
+        # .to_dict() treats NA as NaN; need to replace with None for validation
+        for k, v in row_dict.items():
+            if isinstance(v, float) and pd.isna(v):
+                row_dict[k] = None
+        errors = validate_row_jsonschema(idx, row_dict, schema)
         error_list.append(errors)
     return error_list
 


### PR DESCRIPTION
Pandas dataframes supports `NaN` and `NA` (the latter of which is nullable); however, it converts `NA` to `NaN` during `.to_dict()` operations (required for schema validation). This PR preserves nullable `NA` designations through the `.to_dict()` operation.