### PR TITLE
Add current datetime to csv filenames

### DIFF
--- a/src/InsightBoard/pages/data.py
+++ b/src/InsightBoard/pages/data.py
@@ -1,6 +1,7 @@
 import dash
 import dash_bootstrap_components as dbc
 
+from datetime import datetime
 from dash import dcc, html, dash_table
 from dash import Input, Output, State, callback
 
@@ -91,7 +92,9 @@ def download_table(n_clicks, selected_table):
     if not selected_table or n_clicks == 0:
         return None
 
-    filename = f"{selected_table}.csv"
+    now = datetime.now()
+    datetime_str = now.strftime("%Y-%m-%d_%H-%M-%S")
+    filename = f"{selected_table}_{datetime_str}.csv"
     df = projectObj.database.read_table(selected_table)
     return dcc.send_data_frame(df.to_csv, filename, index=False)
 

--- a/src/InsightBoard/pages/upload.py
+++ b/src/InsightBoard/pages/upload.py
@@ -5,6 +5,7 @@ import dash_bootstrap_components as dbc
 import logging
 
 from pathlib import Path
+from datetime import datetime
 from dash import dcc, html, dash_table, Input, Output, State, callback
 
 import InsightBoard.utils as utils
@@ -856,13 +857,17 @@ def update_table_style_and_validate(
     Output("download-csv", "data"),  # Download the CSV file
     Input("download-button", "n_clicks"),  # Triggered by 'Download as CSV' button
     State("editable-table", "data"),
+    State("imported-tables-dropdown", "value"),
     prevent_initial_call=True,  # Only trigger when the button is clicked
 )
-def download_csv(n_clicks, data):
+def download_csv(n_clicks, data, table_name):
     if n_clicks > 0 and data:
         df = pd.DataFrame(data)
         df.drop(columns=["Row"], inplace=True)
-        return dcc.send_data_frame(df.to_csv, "modified_data.csv", index=False)
+        now = datetime.now()
+        datetime_str = now.strftime("%Y-%m-%d_%H-%M-%S")
+        filename = f"import_{table_name}_{datetime_str}.csv"
+        return dcc.send_data_frame(df.to_csv, filename, index=False)
 
 
 # Display a confirmation dialog when the commit button is clicked

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,20 +100,16 @@ def test_load_config__not_exists():
     assert config == {}
 
 
-def test_merge_configs():
-    ...
+def test_merge_configs(): ...
 
 
-def test_load_and_merge_config():
-    ...
+def test_load_and_merge_config(): ...
 
 
-def test_get_project_folder():
-    ...
+def test_get_project_folder(): ...
 
 
-def test_get_default_project():
-    ...
+def test_get_default_project(): ...
 
 
 def test_set_simple_key():
@@ -145,7 +141,7 @@ def test_set_add_to_existing_nested_key():
 def test_set_deeply_nested_key():
     manager = ConfigManager()
     manager.set("a.b.c.d.e", "value")
-    assert manager.config.get('a', None) == {"b": {"c": {"d": {"e": "value"}}}}
+    assert manager.config.get("a", None) == {"b": {"c": {"d": {"e": "value"}}}}
 
 
 def test_save():
@@ -155,8 +151,8 @@ def test_save():
     config_manager.config_file = "dummy_file.toml"
     config_manager.config = config
     with (
-        mock.patch('builtins.open', mock_open),
-        mock.patch('tomli_w.dump') as mock_tomli_w_dump,
+        mock.patch("builtins.open", mock_open),
+        mock.patch("tomli_w.dump") as mock_tomli_w_dump,
     ):
         config_manager.save()
         mock_open.assert_called_once_with("dummy_file.toml", "wb")

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -55,8 +55,8 @@ def test_adtl_check_parser_fail():
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('win'),
-    reason="File access permissions error on Windows (investigate)"
+    sys.platform.startswith("win"),
+    reason="File access permissions error on Windows (investigate)",
 )
 def test_adtl():
     class mock_Result:
@@ -98,8 +98,8 @@ class mock_adtl_parser:
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('win'),
-    reason="File access permissions error on Windows (investigate)"
+    sys.platform.startswith("win"),
+    reason="File access permissions error on Windows (investigate)",
 )
 @patch("InsightBoard.parsers.adtl_parser", mock_adtl_parser)
 def test_parse_adtl__str():
@@ -114,8 +114,8 @@ def test_parse_adtl__str():
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith('win'),
-    reason="File access permissions error on Windows (investigate)"
+    sys.platform.startswith("win"),
+    reason="File access permissions error on Windows (investigate)",
 )
 @patch("InsightBoard.parsers.adtl_parser", mock_adtl_parser)
 def test_parse_adtl__list():


### PR DESCRIPTION
Add date-time stamps to csv downloads:
- **data page:** new filename `<table_name>_<date>_<time>.csv`, e.g. `linelist_2024-10-08_11-22-42.csv`
- **uploads page:** new filename `import_<table_name>_<date>_<time>.csv`, e.g. `import_linelist_2024-10-08_11-22-42.csv`

Resolves #25 