### PR TITLE
Prevent zeros coercing to nulls

### DIFF
--- a/src/InsightBoard/pages/upload.py
+++ b/src/InsightBoard/pages/upload.py
@@ -332,23 +332,29 @@ def clean_value(x, key_name=None, dtypes={}):
                 )
             )
 
-    if "number" in target_types and isinstance(x, str):
-        try:
-            if "." in x:
-                n = float(x)
-                if math.isnan(n):
-                    return None
-            else:
-                n = int(x)
-            return n
-        except Exception:
-            pass
+    if "number" in target_types:
+        if isinstance(x, int) or isinstance(x, float):
+            return x
+        elif isinstance(x, str):
+            try:
+                if "." in x:
+                    n = float(x)
+                    if math.isnan(n):
+                        return None
+                else:
+                    n = int(x)
+                return n
+            except Exception:
+                pass
 
-    if "integer" in target_types and isinstance(x, str):
-        try:
-            return int(x)  # int cannot be nan
-        except Exception:
-            pass
+    if "integer" in target_types:
+        if isinstance(x, int):
+            return x
+        elif isinstance(x, str):
+            try:
+                return int(x)  # int cannot be nan
+            except Exception:
+                pass
 
     if "boolean" in target_types and isinstance(x, str):
         try:

--- a/tests/pages/test_upload.py
+++ b/tests/pages/test_upload.py
@@ -134,6 +134,7 @@ def test_clean_value():
     number_type = ["k", {"k": {"type": "number"}}]
     integer_type = ["k", {"k": {"type": "integer"}}]
     array_type = ["k", {"k": {"type": "array"}}]
+    number_or_null_type = ["k", {"k": {"type": ["number", "null"]}}]
     assert clean_value("1") == "1"
     assert clean_value("1", *number_type) == 1
     assert clean_value("1", *integer_type) == 1
@@ -149,6 +150,8 @@ def test_clean_value():
     assert clean_value('["a", "b", "c"]', *array_type) == ["a", "b", "c"]
     assert clean_value("'a', 'b', 'c'", *array_type) == ["a", "b", "c"]
     assert clean_value("a, b, c", *array_type) == ["a", "b", "c"]
+    assert clean_value("0", *number_or_null_type) == 0
+    assert clean_value(0, *number_or_null_type) == 0
 
 
 def test_update_edited_data():


### PR DESCRIPTION
Prevent zeros coercing to nulls. This was caused when number types were passed directly into the coercion function.