### PR TITLE
Adopt nox for testing against python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,18 +24,12 @@ jobs:
             3.12
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v2
-
-      - name: Setup test environment
+      - name: Run unit tests
         run: |
-          uv sync --all-extras
-          uv pip install "adtl[parquet] @ git+https://github.com/globaldothealth/adtl"
-
-      - name: Unit tests (and coverage report)
+          uvx nox -s unit_tests
+      - name: Run system tests
         run: |
-          uv run pytest --cov=InsightBoard --cov-report=html tests/unit
-      - name: System tests
-        run: |
-          uv run pytest tests/system
+          uvx nox -s system_tests
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
@@ -58,7 +52,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '<img src="data:image/png;base64,'$(cat screenshot_base64.txt)'" alt="Screenshot"/>' >> $GITHUB_STEP_SUMMARY
           fi
-      - name: Upload screenshot as artifact
+      - name: Upload screenshot as artifact (on system test failure)
         if: failure()
         uses: actions/upload-artifact@v3
         with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,45 @@
+import nox
+
+PYTHON_VERSIONS = ["3.11", "3.12"]
+
+
+@nox.session(python=PYTHON_VERSIONS, venv_backend="uv")
+def unit_tests(session):
+    """Unit tests (with coverage)"""
+    session.env.update({"UV_PROJECT_ENVIRONMENT": session.virtualenv.location})
+    session.run(
+        "uv",
+        "sync",
+        "--all-extras",
+    )
+    session.run(
+        "uv",
+        "run",
+        "pytest",
+        "--cov=InsightBoard",
+        "--cov-report=html",
+        "tests/unit",
+    )
+
+
+@nox.session(python=PYTHON_VERSIONS, venv_backend="uv")
+def system_tests(session):
+    """System tests"""
+    session.env.update({"UV_PROJECT_ENVIRONMENT": session.virtualenv.location})
+    session.run(
+        "uv",
+        "sync",
+        "--all-extras",
+    )
+    session.run(
+        "uv",
+        "pip",
+        "install",
+        "adtl[parquet] @ git+https://github.com/globaldothealth/adtl",
+    )
+    session.run(
+        "uv",
+        "run",
+        "pytest",
+        "tests/system",
+    )


### PR DESCRIPTION
- Adopt nox as the primary testing framework.
- Test against multiple Python versions (3.11, 3.12)