### PR TITLE
Add Python 3.13 to test framework

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
           python-version: |
             3.11
             3.12
+            3.13
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v2
       - name: Run unit tests

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-PYTHON_VERSIONS = ["3.11", "3.12"]
+PYTHON_VERSIONS = ["3.11", "3.12", "3.13"]
 
 
 @nox.session(python=PYTHON_VERSIONS, venv_backend="uv")


### PR DESCRIPTION
- Add Python 3.13 to test framework

_Note: pyarrow is currently unavailable as a binary for Python 3.13 which is producing slow/failed builds. Rerun this PRs tests when this is resolved **before** merging_