### PR TITLE
Add settings toggle for upsert/append

### DIFF
--- a/src/InsightBoard/database/__init__.py
+++ b/src/InsightBoard/database/__init__.py
@@ -1,1 +1,1 @@
-from .database import Database, DatabaseBackend  # noqa: F401
+from .database import Database, DatabaseBackend, WritePolicy, BackupPolicy  # noqa: F401

--- a/src/InsightBoard/database/database.py
+++ b/src/InsightBoard/database/database.py
@@ -1,17 +1,30 @@
 import os
 import json
+import shutil
 import pandas as pd
 import pyarrow.parquet as pq
 
+from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
 from pyarrow import Table
+from datetime import datetime
 from functools import cache
-from abc import ABC, abstractmethod
 
 
 class DatabaseBackend(Enum):
     PARQUET = "parquet"
+
+
+class WritePolicy(Enum):
+    APPEND = "append"  # Append new data, do not overwrite existing records
+    UPSERT = "upsert"  # Update existing records, insert new records
+
+
+class BackupPolicy(Enum):
+    NONE = "none"
+    VERSIONED = "versioned"  # Versioned records are kept in the tables
+    BACKUP = "backup"  # Backup the table before writing new data
 
 
 class DatabaseBase(ABC):
@@ -22,6 +35,14 @@ class DatabaseBase(ABC):
     ):
         self.BACKEND = backend
         self.data_folder = data_folder
+        self.write_policy = WritePolicy.UPSERT
+        self.backup_policy = BackupPolicy.NONE
+
+    def set_write_policy(self, policy: WritePolicy):
+        self.write_policy = policy
+
+    def set_backup_policy(self, policy: BackupPolicy):
+        self.backup_policy = policy
 
     def commit_tables_dict(self, table_names: [str], datasets: [dict]):
         if not isinstance(table_names, list):
@@ -55,13 +76,19 @@ class DatabaseBase(ABC):
         # Find field that has the 'PrimaryKey' set to 'True'
         primary_key = None
         primary_key_count = 0
-        for field_name, d in schema["properties"].items():
+        for field_name, d in schema.get("properties", {}).items():
             if d.get("PrimaryKey", None):
                 primary_key = field_name
                 primary_key_count = primary_key_count + 1
         if primary_key_count > 1:
             raise ValueError(f"Table '{table_name}' has more than one primary key.")
         return primary_key
+
+    def get_primary_keys(self, table_name: str):
+        primary_key = self.get_primary_key(table_name)
+        if not primary_key:
+            return []
+        return self.read_table_column(table_name, primary_key).tolist()
 
     @cache
     def get_table_schema(self, table_name: str):
@@ -72,7 +99,7 @@ class DatabaseBase(ABC):
             with open(schema_filename, "r") as f:
                 schema = json.load(f)
         except FileNotFoundError:
-            return None
+            return {}
         return schema
 
     @abstractmethod
@@ -81,6 +108,10 @@ class DatabaseBase(ABC):
 
     @abstractmethod
     def read_table(self, table_name: str) -> pd.DataFrame:
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def read_table_column(self, table_name: str, column_name: str) -> pd.Series:
         pass  # pragma: no cover
 
     @abstractmethod
@@ -109,27 +140,76 @@ class DatabaseParquet(DatabaseBase):
         return table.to_pandas()
 
     # override
+    def read_table_column(self, table_name: str, column_name: str) -> pd.Series:
+        file_path = f"{self.data_folder}/{table_name}.parquet"
+        table = pq.read_table(file_path)
+        return table[column_name].to_pandas()
+
+    # override
     def commit_table(self, table_name: str, df: pd.DataFrame):
         self.write_table_parquet(table_name, df)
 
     # Utility functions
 
-    def write_table_parquet(self, table_name: str, df: pd.DataFrame):
+    def backup(self, file_path, backup_policy: BackupPolicy = None):
+        backup_policy = backup_policy or self.backup_policy
+        if backup_policy == BackupPolicy.BACKUP:
+            backup_folder = Path(self.data_folder) / "backup"
+            backup_folder.mkdir(parents=True, exist_ok=True)
+            datetime_stamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            shutil.copy(file_path, f"{file_path.stem}_{datetime_stamp}_.backup")
+
+    def write_table_parquet(
+        self,
+        table_name: str,
+        df: pd.DataFrame,
+        write_policy: WritePolicy = None,
+        backup_policy: BackupPolicy = None,
+    ):
         """Plain Parquet writer, no version history"""
-        # Check if the Parquet file exists, and append the data
+        write_policy = write_policy or self.write_policy
+        backup_policy = backup_policy or self.backup_policy
+        if len(df) == 0:
+            return
         file_path = Path(self.data_folder) / f"{table_name}.parquet"
         file_path.parent.mkdir(parents=True, exist_ok=True)
+        primary_key = self.get_primary_key(table_name)
+        if primary_key and primary_key not in df.columns:
+            raise ValueError(
+                f"Primary key '{primary_key}' not found in new DataFrame columns."
+            )
         if file_path.exists():
-            current_df = pq.read_table(file_path).to_pandas()
-            primary_key = self.get_primary_key(table_name)
-            if primary_key:
-                current_df = current_df[~current_df[primary_key].isin(df[primary_key])]
-            combined_df = pd.concat([current_df, df], ignore_index=True)
+            old_df = pq.read_table(file_path).to_pandas()
+            if not primary_key:
+                # No primary key, just append the new data
+                combined_df = pd.concat([old_df, df], ignore_index=True)
+            if primary_key not in df.columns:
+                raise ValueError(
+                    f"Critical error - primary key '{primary_key}' not found in existing database."
+                )
+            match write_policy:
+                case WritePolicy.APPEND:
+                    # Remove matching keys from the new DataFrame
+                    df = df[~df[primary_key].isin(old_df[primary_key])]
+                    # Combine old and new DataFrames (no duplicate primary keys)
+                    combined_df = pd.concat([old_df, df], ignore_index=True)
+                case WritePolicy.UPSERT:
+                    # Remove matching keys from old DataFrame
+                    old_df = old_df[~old_df[primary_key].isin(df[primary_key])]
+                    # Combine old and new DataFrames (no duplicate primary keys)
+                    combined_df = pd.concat([old_df, df], ignore_index=True)
+                case _:
+                    raise ValueError(
+                        f"Requested WritePolicy '{write_policy}' is not supported."
+                    )
         else:
+            # First time writing to the file
             combined_df = df
         # Write the updated DataFrame to the Parquet file
         table = Table.from_pandas(combined_df)
         pq.write_table(table, file_path)
+        # Create a timestamped version of the database as a backup
+        self.backup(file_path)
 
 
 class Database:

--- a/tests/unit/pages/test_upload.py
+++ b/tests/unit/pages/test_upload.py
@@ -81,6 +81,7 @@ def test_update_table():
     edited_datasets = [table1, table2]
     parsed_datasets = edited_datasets
     only_show_validation_errors = False
+    update_existing_records = True
     errors = []
 
     # Mock clean_dataset
@@ -96,6 +97,7 @@ def test_update_table():
             selected_table,
             unique_table_id,
             only_show_validation_errors,
+            update_existing_records,
             project,
             edited_datasets,
             parsed_datasets,
@@ -118,6 +120,7 @@ def test_update_table():
             selected_table,
             unique_table_id,
             only_show_validation_errors,
+            update_existing_records,
             project,
             edited_datasets,
             parsed_datasets,


### PR DESCRIPTION
- Add settings toggle for upsert/append
- Supported with database 'backup' and 'write' policy options
- Only show rows with unique IDs when appending; show all record when upserting
- Added alerts to more clearly indicate success or failure on database commits


## Example
Toggle is shown at the bottom of the second screenshot

### Upsert mode
`update existing records`: **on**

![Screenshot 2024-10-10 at 10 35 07](https://github.com/user-attachments/assets/2ed0f1b7-6b3e-4212-9bd3-8952abcb3e39)

### Append mode
`update existing records`: **off**

![Screenshot 2024-10-10 at 10 35 20](https://github.com/user-attachments/assets/36d9c0b5-6487-4049-8234-904d6927f684)