### PR TITLE
Add Python version compatbility badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Unit and integration tests](https://github.com/globaldothealth/InsightBoard/actions/workflows/ci.yaml/badge.svg)](https://github.com/globaldothealth/InsightBoard/actions/workflows/ci.yaml) [![Documentation Status](https://readthedocs.org/projects/insightboard/badge/?version=latest)](https://insightboard.readthedocs.io/en/latest/?badge=latest)
 
+[![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/) [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-3120/) [![Python 3.13](https://img.shields.io/badge/python-3.13-red.svg)](https://www.python.org/downloads/release/python-3130/)
+
 A dashboard to upload and manage data and generate reports.
 
 Documentation: [ReadTheDocs](https://insightboard.readthedocs.io/en/latest)


### PR DESCRIPTION
- Add Python version compatbility badges

This is primarily to inform the user that we currently support Python 3.11/3.12, but that 3.13 is not yet supported.
![Screenshot 2024-10-10 at 10 40 58](https://github.com/user-attachments/assets/b7186b21-dfb6-486c-8207-b14bd46a671b)
