### PR TITLE
Rename 'database' to 'table' in parser return

### DIFF
--- a/docs/projects/components/parsers.md
+++ b/docs/projects/components/parsers.md
@@ -32,7 +32,7 @@ def parse(data: pd.DataFrame) -> list[dict]:
 
     return [
         {
-            "database": "linelist",     # Target table = "linelist"
+            "table": "linelist",     # Target table = "linelist"
             "data": data,               # Parsed data
         },
     ]
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # Validate that the output is as expected
     df = tables[0]["data"]
     assert isinstance(df, pd.DataFrame)
-    assert tables[0]["database"] == "linelist"
+    assert tables[0]["table"] == "linelist"
     assert df.columns.tolist() == ["date", "country", "value"]
     assert df["country"].tolist() == ["United States", "United Kingdom"]
     # Print the parsed data

--- a/src/InsightBoard/pages/upload.py
+++ b/src/InsightBoard/pages/upload.py
@@ -776,8 +776,10 @@ def parse_data(project, contents, filename, selected_parser):
         projectObj = utils.get_project(project)
         parsed_df_list = projectObj.load_and_parse(filename, contents, selected_parser)
 
-        parsed_dbs = [d["database"] for d in parsed_df_list]
-        parsed_dfs = [d["data"] for d in parsed_df_list]
+        # Extract the table names and data from the parsed data
+        # NB: Parsers originally used 'database' instead of 'table' as table name
+        parsed_dbs = [d.get("table", d.get("database")) for d in parsed_df_list]
+        parsed_dfs = [d.get("data") for d in parsed_df_list]
 
         # Dash cannot store DataFrames directly, so convert them to dictionaries
         parsed_dbs_dict = [df.to_dict("records") for df in parsed_dfs]
@@ -799,7 +801,9 @@ def parse_data(project, contents, filename, selected_parser):
 
     except Exception as e:
         return (
-            f"There was an error processing the file: {str(e)}",
+            dbc.Alert(
+                f"There was an error processing the file: {str(e)}", color="danger"
+            ),
             None,
             [],
             "",

--- a/src/InsightBoard/parsers/__init__.py
+++ b/src/InsightBoard/parsers/__init__.py
@@ -74,7 +74,7 @@ def parse_adtl(df: pd.DataFrame, spec_file, table_names) -> list[dict]:
 
     return [
         {
-            "database": table_name,
+            "table": table_name,
             "data": df,
         }
         for table_name, df in zip(table_names, dfs)

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1,4 +1,3 @@
-import sys
 import importlib
 from unittest import mock
 import pytest
@@ -101,7 +100,7 @@ def test_parse_adtl__str():
     dbs = parse_adtl(df, spec_file, table_names)
     assert len(dbs) == 1
     db1 = dbs[0]
-    assert db1["database"] == "table1"
+    assert db1["table"] == "table1"
     assert db1["data"]["name"].equals(df["name"])
 
 
@@ -113,7 +112,7 @@ def test_parse_adtl__list():
     dbs = parse_adtl(df, spec_file, table_names)
     len(dbs) == 2
     db1, db2 = dbs
-    assert db1["database"] == "table1"
+    assert db1["table"] == "table1"
     assert db1["data"]["name"].equals(df["name"])
-    assert db2["database"] == "table2"
+    assert db2["table"] == "table2"
     assert db2["data"]["name"].equals(df["name"])


### PR DESCRIPTION
Rename 'database' to 'table' in parser return
The return 'database' is still supported in the upload page for backwards-compatibility.