### PR TITLE
Add versioned parquet backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "tomli-w>=1.0.0",
     "waitress>=3.0.0",
     "cachetools>=5.5.0",
+    "dash-bootstrap-templates>=1.2.4",
 ]
 scripts = { InsightBoard = "InsightBoard:main" }
 dynamic = ["version"]

--- a/src/InsightBoard/app.py
+++ b/src/InsightBoard/app.py
@@ -120,7 +120,7 @@ app.layout = dbc.Container(
                     ],
                 ),
             ],
-            style={'display': 'none'}
+            style={"display": "none"},
         ),
         dbc.NavbarSimple(
             children=[

--- a/src/InsightBoard/app.py
+++ b/src/InsightBoard/app.py
@@ -105,7 +105,8 @@ def store_selected_project(project):
 
 app.layout = dbc.Container(
     [
-        dcc.Store(id="project", storage_type="memory", data=default_project),
+        dcc.Store(id="project", data=default_project),
+        dcc.Store(id="dark-mode", data=False),
         dbc.NavbarSimple(
             children=[
                 dbc.NavLink("Home", href="/"),
@@ -134,6 +135,19 @@ app.layout = dbc.Container(
         html.Div(dash.page_container, id="page-content"),
     ],
 )
+
+
+@app.callback(
+    Output("app-container", "external_stylesheets"),
+    Input("dark-mode", "data"),
+)
+def apply_dark_mode(dark_mode):
+    print("Dark mode trigger (app.py): ", dark_mode)
+    if dark_mode:
+        return dbc.themes.DARKLY
+    else:
+        return dbc.themes.BOOTSTRAP
+
 
 # Client-side callback to check server status every second
 app.clientside_callback(

--- a/src/InsightBoard/app.py
+++ b/src/InsightBoard/app.py
@@ -1,8 +1,9 @@
 import sys
 import dash
+import dash_bootstrap_templates as dbt
 import dash_bootstrap_components as dbc
 
-from dash import dcc, html, Input, Output
+from dash import dcc, html, callback, Input, Output
 from pathlib import Path
 
 from InsightBoard.config import ConfigManager
@@ -34,6 +35,8 @@ custom_css = (
 )
 cogwheel = (html.I(className="fas fa-cog"),)
 pages_path = base_path / "pages"
+config = ConfigManager()
+dark_mode = config.get("theme.dark_mode", False)
 
 app = dash.Dash(
     __name__,
@@ -94,7 +97,7 @@ def ProjectDropDown():
     )
 
 
-@app.callback(Output("project", "data"), Input("project-dropdown", "value"))
+@callback(Output("project", "data"), Input("project-dropdown", "value"))
 def store_selected_project(project):
     config = ConfigManager()
     if project:
@@ -106,7 +109,19 @@ def store_selected_project(project):
 app.layout = dbc.Container(
     [
         dcc.Store(id="project", data=default_project),
-        dcc.Store(id="dark-mode", data=False),
+        dcc.Store(id="dark-mode", data=dark_mode),
+        html.Div(
+            [
+                dbt.ThemeSwitchAIO(
+                    aio_id="theme",
+                    themes=[
+                        dbc.themes.BOOTSTRAP,
+                        dbc.themes.DARKLY,
+                    ],
+                ),
+            ],
+            style={'display': 'none'}
+        ),
         dbc.NavbarSimple(
             children=[
                 dbc.NavLink("Home", href="/"),
@@ -135,18 +150,6 @@ app.layout = dbc.Container(
         html.Div(dash.page_container, id="page-content"),
     ],
 )
-
-
-@app.callback(
-    Output("app-container", "external_stylesheets"),
-    Input("dark-mode", "data"),
-)
-def apply_dark_mode(dark_mode):
-    print("Dark mode trigger (app.py): ", dark_mode)
-    if dark_mode:
-        return dbc.themes.DARKLY
-    else:
-        return dbc.themes.BOOTSTRAP
 
 
 # Client-side callback to check server status every second
@@ -179,3 +182,14 @@ app.clientside_callback(
     Output("server-status", "children"),
     Input("interval", "n_intervals"),
 )
+
+
+@callback(
+    Output(dbt.ThemeSwitchAIO.ids.switch("theme"), "value"),
+    Input("project", "data"),
+    Input("dark-mode", "data"),
+)
+def set_theme(project, dark_mode):
+    config = ConfigManager()
+    dark_mode = config.get("theme.dark_mode", False)
+    return not dark_mode

--- a/src/InsightBoard/config/config.py
+++ b/src/InsightBoard/config/config.py
@@ -80,6 +80,10 @@ class ConfigManager:
         """Get the project folder from the configuration."""
         return self.config.get("project", {}).get("folder", None)
 
+    def set_project_folder(self, folder):
+        """Set the project folder in the configuration."""
+        self.set("project.folder", folder)
+
     def get_default_project(self):
         """Get the default project from the configuration."""
         return self.config.get("project", {}).get("default", None)

--- a/src/InsightBoard/database/database.py
+++ b/src/InsightBoard/database/database.py
@@ -14,6 +14,7 @@ from cachetools import cached, TTLCache
 
 class DatabaseBackend(Enum):
     PARQUET = "parquet"
+    PARQUET_VERSIONED = "parquet_versioned"
 
 
 class WritePolicy(Enum):

--- a/src/InsightBoard/pages/reports.py
+++ b/src/InsightBoard/pages/reports.py
@@ -13,7 +13,7 @@ projectObj = None
 def layout():
     return html.Div(
         [
-            html.H3("Select a Report"),
+            html.H1("Report"),
             dcc.Store(id="project", storage_type="memory"),  # Store the project name
             dcc.Dropdown(id="report-dropdown", placeholder="Select a report"),
             dcc.Loading(

--- a/src/InsightBoard/pages/settings.py
+++ b/src/InsightBoard/pages/settings.py
@@ -1,5 +1,10 @@
 import dash
-from dash import html
+from dash import html, dcc, callback, Input, Output, State
+import dash_bootstrap_components as dbc
+
+import InsightBoard.utils as utils
+from InsightBoard.config import ConfigManager
+from InsightBoard.database import BackupPolicy
 
 # Register the page
 dash.register_page(__name__, path="/settings")
@@ -7,9 +12,146 @@ dash.register_page(__name__, path="/settings")
 
 # Layout for the Data Page
 def layout():
+    # Load the configuration
+    config = ConfigManager()
+    project_folder = config.get_project_folder()
+
+    db_backend = "parquet"
+
+    db_backup_policy_list = [
+        {"label": "None", "value": str(BackupPolicy.NONE)},
+        {"label": "Versioned", "value": str(BackupPolicy.VERSIONED)},
+        {"label": "Timestamp copies", "value": str(BackupPolicy.BACKUP)},
+    ]
+    db_backup = str(BackupPolicy.NONE)
+
     return html.Div(
         [
-            html.H1("Settings"),
-            html.Div(["There are no editable settings available at this time."]),
+            # Store
+            html.H1(
+                "Settings",
+                style={"width": "67%", "minWidth": "400px", "maxWidth": "800px", "border": "none"},
+            ),
+            dbc.Card(
+                dbc.CardBody(
+                    [
+                        html.H4("Global settings"),
+                        html.P("These settings apply to all projects."),
+                        html.H5("Project folder"),
+                        dcc.Input(
+                            id="project-folder",
+                            value=project_folder,
+                            style={"width": "100%"},
+                        ),
+                        html.H5("Dark mode"),
+                        dbc.Checklist(
+                            id="dark-mode-toggle",
+                            options=[
+                                {"label": "Dark mode", "value": 1},
+                            ],
+                            value=[],  # list of 'value's that are 'on' by default
+                            inline=True,
+                            switch=True,
+                        ),
+                    ]
+                ),
+                style={"width": "67%", "minWidth": "400px", "maxWidth": "800px"},
+            ),
+            dbc.Card(
+                dbc.CardBody(
+                    [
+                        html.H4("Project settings"),
+                        html.P(
+                            "These settings apply to the current project: {project}",
+                            id="project-info",
+                        ),
+                        html.H5("Database"),
+                        html.H6("Backend"),
+                        dbc.Col(
+                            dcc.Dropdown(
+                                id="db-backend-dropdown",
+                                options=[
+                                    {
+                                        "label": "Flat file (parquet)",
+                                        "value": "parquet",
+                                    },
+                                ],
+                                value=db_backend,
+                                clearable=False,
+                                style={"width": "100%"},
+                            ),
+                            width=12,
+                        ),
+                        html.H6("Backup policy"),
+                        dbc.Col(
+                            dcc.Dropdown(
+                                id="db-backup-dropdown",
+                                options=db_backup_policy_list,
+                                clearable=False,
+                                value=db_backup,
+                                style={"width": "100%"},
+                            ),
+                            width=12,
+                        ),
+                        html.Br(),
+                        dbc.Button("Set as defaults", color="primary"),
+                    ]
+                ),
+                style={"width": "67%", "minWidth": "400px", "maxWidth": "800px"},
+            ),
+        ],
+        style={
+            "display": "flex",
+            "width": "100%",
+            "justify-content": "center",
+            "align-items": "center",
+            "flex-direction": "column",
+            "gap": "20px",
+        },
+    )
+
+
+@callback(
+    Output("project-info", "children"),
+    Input("project", "data"),
+)
+def update_project_info(project):
+    return html.Div(
+        [
+            "These settings apply to the current project: ",
+            html.B(project),
         ]
     )
+
+
+@callback(
+    Input("project-folder", "value"),
+)
+def update_project_folder(value):
+    config = ConfigManager()
+    config.set_project_folder(value)
+
+
+@callback(
+    Input("dark-mode", "data"),
+)
+def update_dark_mode(value):
+    print("Dark mode:", value)
+
+
+def register_callbacks(app):
+    @callback(
+        Output("dark-mode", "data"),
+        Input("dark-mode-toggle", "value"),
+    )
+    def set_dark_mode(value):
+        return 1 in value
+
+
+@callback(
+    Input("db-backup-dropdown", "value"),
+    State("project", "data"),
+)
+def update_db_backup(db_backup_policy, project):
+    projectObj = utils.get_project(project)
+    projectObj.set_db_backup_policy(db_backup_policy)

--- a/src/InsightBoard/pages/settings.py
+++ b/src/InsightBoard/pages/settings.py
@@ -1,5 +1,4 @@
 import dash
-import dash_bootstrap_templates as dbt
 import dash_bootstrap_components as dbc
 
 from dash import html, dcc, callback, Input, Output, State
@@ -22,7 +21,7 @@ def layout():
 
     db_backend_list = [
         {"label": "Flat file (Parquet, unversioned)", "value": "parquet"},
-        {"label": "Flat file (Parquet, versioned)", "value": "parquet_versioned"}
+        {"label": "Flat file (Parquet, versioned)", "value": "parquet_versioned"},
     ]
     db_backend = "parquet"
 
@@ -38,7 +37,12 @@ def layout():
             # Store
             html.H1(
                 "Settings",
-                style={"width": "67%", "minWidth": "400px", "maxWidth": "800px", "border": "none"},
+                style={
+                    "width": "67%",
+                    "minWidth": "400px",
+                    "maxWidth": "800px",
+                    "border": "none",
+                },
             ),
             dbc.Card(
                 dbc.CardBody(

--- a/src/InsightBoard/pages/upload.py
+++ b/src/InsightBoard/pages/upload.py
@@ -209,7 +209,6 @@ def layout():
                         "Commit to Database",
                         id="commit-button",
                         n_clicks=0,
-                        disabled=True,
                         style={
                             "float": "right",
                             "margin": "10px",
@@ -1149,7 +1148,6 @@ def display_confirm_dialog(n_clicks, table_names):
 # Commit changes to the database
 @callback(
     Output("commit-output", "children"),  # Update the commit output message ...
-    Output("commit-button", "disabled"),  # ... and disable the commit button
     Input("confirm-commit-dialog", "submit_n_clicks"),  # Triggered by 'Confirm' dialog
     State("project", "data"),
     State("imported-tables-dropdown", "options"),
@@ -1174,10 +1172,8 @@ def commit_to_database(
                     for row in datasets[i]
                 ]
             projectObj.database.commit_tables_dict(table_names, datasets)
-            return dbc.Alert("Data committed to database.", color="success"), True
+            return dbc.Alert("Data committed to database.", color="success")
         except Exception as e:
-            return dbc.Alert(
-                f"Error committing data to file: {str(e)}", color="danger"
-            ), False
+            return dbc.Alert(f"Error committing data to file: {str(e)}", color="danger")
 
-    return "No data committed yet.", False
+    return "No data committed yet."

--- a/src/InsightBoard/pages/upload.py
+++ b/src/InsightBoard/pages/upload.py
@@ -929,7 +929,9 @@ def parse_data(project, contents, filename, selected_parser):
     except Exception as e:
         return (
             dbc.Alert(
-                f"There was an error processing the file: {str(e)}", color="danger"
+                f"There was an error processing the file: {str(e)}. "
+                "Have you selected a compatible parser?",
+                color="danger",
             ),
             None,
             [],

--- a/src/InsightBoard/pages/upload.py
+++ b/src/InsightBoard/pages/upload.py
@@ -29,6 +29,7 @@ def layout():
     return html.Div(
         [
             # Store
+            dcc.Store(id="project"),  # project selection
             dcc.Store(id="unique-table-id"),  # unique id (project-table)
             dcc.Store(id="parsed-data-store"),  # parsed data (multi-table support)
             dcc.Store(id="edited-data-store"),  # edited data (multi-table support)

--- a/src/InsightBoard/pages/upload.py
+++ b/src/InsightBoard/pages/upload.py
@@ -29,7 +29,6 @@ def layout():
     return html.Div(
         [
             # Store
-            dcc.Store(id="project"),  # current project (from navbar)
             dcc.Store(id="unique-table-id"),  # unique id (project-table)
             dcc.Store(id="parsed-data-store"),  # parsed data (multi-table support)
             dcc.Store(id="edited-data-store"),  # edited data (multi-table support)
@@ -168,45 +167,56 @@ def layout():
             # Buttons for row operations (on the next line)
             html.Div(id="data-stats"),
             html.Div(id="commit-output"),
-            html.Div([
-                dbc.Button(
-                    "Reject rows with empty IDs",
-                    id="remove-empty-ids-button",
-                    n_clicks=0,
-                    style={"marginRight": "5px"},
-                ),
-                dbc.Button(
-                    "Reject rows with any errors",
-                    id="remove-error-rows-button",
-                    n_clicks=0,
-                    style={"margin": "5px"},
-                ),
-                dbc.Button(
-                    "Restore deleted rows",
-                    id="restore-deleted-rows-button",
-                    n_clicks=0,
-                    style={"margin": "5px"},
-                ),
-                html.Br(),
-                # Button for reparsing edited data
-                dbc.Button("Update & validate", id="update-button", n_clicks=0, style={"marginRight": "5px"}),
-                # Buttons for downloading CSV and committing changes
-                dbc.Button(
-                    "Download as CSV",
-                    id="download-button",
-                    n_clicks=0,
-                    style={"margin": "5px"},
-                ),
-                dcc.Download(id="download-csv"),
-                # Commit Button moved to the right-hand side
-                dbc.Button(
-                    "Commit to Database",
-                    id="commit-button",
-                    n_clicks=0,
-                    disabled=True,
-                    style={"float": "right", "margin": "10px", "verticalAlign": "middle"},
-                ),
-            ]),
+            html.Div(
+                [
+                    dbc.Button(
+                        "Reject rows with empty IDs",
+                        id="remove-empty-ids-button",
+                        n_clicks=0,
+                        style={"marginRight": "5px"},
+                    ),
+                    dbc.Button(
+                        "Reject rows with any errors",
+                        id="remove-error-rows-button",
+                        n_clicks=0,
+                        style={"margin": "5px"},
+                    ),
+                    dbc.Button(
+                        "Restore deleted rows",
+                        id="restore-deleted-rows-button",
+                        n_clicks=0,
+                        style={"margin": "5px"},
+                    ),
+                    html.Br(),
+                    # Button for reparsing edited data
+                    dbc.Button(
+                        "Update & validate",
+                        id="update-button",
+                        n_clicks=0,
+                        style={"marginRight": "5px"},
+                    ),
+                    # Buttons for downloading CSV and committing changes
+                    dbc.Button(
+                        "Download as CSV",
+                        id="download-button",
+                        n_clicks=0,
+                        style={"margin": "5px"},
+                    ),
+                    dcc.Download(id="download-csv"),
+                    # Commit Button moved to the right-hand side
+                    dbc.Button(
+                        "Commit to Database",
+                        id="commit-button",
+                        n_clicks=0,
+                        disabled=True,
+                        style={
+                            "float": "right",
+                            "margin": "10px",
+                            "verticalAlign": "middle",
+                        },
+                    ),
+                ]
+            ),
             dcc.ConfirmDialog(id="confirm-commit-dialog", message=""),
             dbc.Checklist(
                 id="upload-settings",
@@ -360,7 +370,11 @@ def update_table(
     trig_restore_deleted_rows = ctx_trigger(ctx, "restore-deleted-rows-button.n_clicks")
 
     # The only active cell we want to respond to is the delete button
-    if trig_active_cell and active_cell and not active_cell.get("column_id") == _DELETE_COLUMN:
+    if (
+        trig_active_cell
+        and active_cell
+        and not active_cell.get("column_id") == _DELETE_COLUMN
+    ):
         raise dash.exceptions.PreventUpdate
 
     data = datasets[options.index(selected_table)]
@@ -412,7 +426,9 @@ def update_table(
             row[_DELETE_COLUMN] = _DELETE_FALSE
 
     # Check how many visible rows are marked for deletion
-    deleted_rows = len([row for row in data if row.get(_DELETE_COLUMN, _DELETE_FALSE) == _DELETE_TRUE])
+    deleted_rows = len(
+        [row for row in data if row.get(_DELETE_COLUMN, _DELETE_FALSE) == _DELETE_TRUE]
+    )
 
     # Move columns '_delete' and 'Row' to the front
     columns = [

--- a/src/InsightBoard/project/project.py
+++ b/src/InsightBoard/project/project.py
@@ -162,9 +162,9 @@ class Project:
         if not data_folder.exists():
             return []
         return [
-            {"filename": f, "label": f.with_suffix("").name}
+            {"filename": f, "label": f.name[: -len(self.database.suffix) - 1]}
             for f in data_folder.iterdir()
-            if f.is_file() and f.suffix == ".parquet"
+            if f.is_file() and f.name.endswith(self.database.suffix)
         ]
 
     def get_project_parsers(self):
@@ -187,7 +187,7 @@ class Project:
                 f"Available datasets: {[d['label'] for d in project_datasets]}"
             )
         datasets = [d for d in project_datasets if d["label"] in datasets]
-        return [pd.read_parquet(f"{d['filename']}") for d in datasets]
+        return [self.database.read_table(d["label"]) for d in datasets]
 
     def load_and_parse(self, filename, contents, selected_parser):
         content_type, content_string = contents.split(",")

--- a/src/InsightBoard/project/project.py
+++ b/src/InsightBoard/project/project.py
@@ -72,11 +72,13 @@ class Project:
                 f"Project '{self.name}' does not exist in '{self.projects_folder}'."
             )
         self.default_config = {
-            "name": self.name,
+            "project": {
+                "name": self.name,
+            },
             "database": {
-                "backend": "parquet",
+                "backend": DatabaseBackend.PARQUET.value,
                 "data_folder": "data",
-                "backup_policy": BackupPolicy.NONE,
+                "backup_policy": BackupPolicy.NONE.value,
             },
         }
         self.config = self.load_config()
@@ -99,10 +101,30 @@ class Project:
         with open(config_path, "wb") as f:
             tomli_w.dump(self.config, f)
 
-    def set_db_backup_policy(self, policy):
+    def set_db_backup_policy(self, policy: BackupPolicy | str):
+        if isinstance(policy, BackupPolicy):
+            policy = policy.value
+        opts = [v.value for v in BackupPolicy.__members__.values()]
+        if policy not in opts:
+            raise ValueError(f"Invalid BackupPolicy value: {policy} (options are: {opts})")
         self.database.set_backup_policy(policy)
         self.config["database"]["backup_policy"] = policy
         self.save_config()
+
+    def get_db_backup_policy(self):
+        return self.config["database"]["backup_policy"]
+
+    def set_db_backend(self, backend: DatabaseBackend | str):
+        if isinstance(backend, DatabaseBackend):
+            backend = backend.value
+        opts = [v.value for v in DatabaseBackend.__members__.values()]
+        if backend not in opts:
+            raise ValueError(f"Invalid DatabaseBackend value: {backend} (options are: {opts})")
+        self.config["database"]["backend"] = backend
+        self.save_config()
+
+    def get_db_backend(self):
+        return self.config["database"]["backend"]
 
     def get_reports_folder(self):
         return f"{self.project_folder}/reports"

--- a/src/InsightBoard/project/project.py
+++ b/src/InsightBoard/project/project.py
@@ -106,7 +106,9 @@ class Project:
             policy = policy.value
         opts = [v.value for v in BackupPolicy.__members__.values()]
         if policy not in opts:
-            raise ValueError(f"Invalid BackupPolicy value: {policy} (options are: {opts})")
+            raise ValueError(
+                f"Invalid BackupPolicy value: {policy} (options are: {opts})"
+            )
         self.database.set_backup_policy(policy)
         self.config["database"]["backup_policy"] = policy
         self.save_config()
@@ -119,7 +121,12 @@ class Project:
             backend = backend.value
         opts = [v.value for v in DatabaseBackend.__members__.values()]
         if backend not in opts:
-            raise ValueError(f"Invalid DatabaseBackend value: {backend} (options are: {opts})")
+            raise ValueError(
+                f"Invalid DatabaseBackend value: {backend} (options are: {opts})"
+            )
+        # Create a new database backend
+        self.database = Database(backend=backend, data_folder=self.get_data_folder())
+        # Update configuration
         self.config["database"]["backend"] = backend
         self.save_config()
 

--- a/tests/system/utils.py
+++ b/tests/system/utils.py
@@ -4,6 +4,7 @@ import tomllib
 import tomli_w
 
 import InsightBoard
+from InsightBoard.config import ConfigManager
 
 from pathlib import Path
 from selenium import webdriver
@@ -47,7 +48,8 @@ def driver():
     driver = webdriver.Chrome(service=service, options=options)
 
     # Override default project location
-    config_file = Path.home() / ".insightboard" / "config.toml"
+    manager = ConfigManager()
+    config_file = manager.config_file
     try:
         with open(config_file, "r") as f:
             config = tomllib.loads(f.read())

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 from unittest import mock
 from unittest.mock import patch
 from InsightBoard.config import ConfigManager
@@ -22,59 +24,66 @@ class mock_Dir:
         return None
 
 
-def test_singleton():
+@pytest.fixture
+def manager():
+    """ConfigManager is a singleton instance
+    Ensure it is reset before each test to avoid test pollution.
+    """
+    ConfigManager()._instance = None  # Reset the singleton instance
+    manager = ConfigManager()
+    manager.config = {}
+    return manager
+
+
+def test_singleton(manager):
     # ConfigManager is a singleton instance
+    assert manager
     config = ConfigManager()
     assert config
-    config2 = ConfigManager()
-    assert config2
-    assert config == config2
+    assert manager is config
 
 
-def test_init():
-    config = ConfigManager()
+def test_init(manager):
+    config = manager
     assert config.config_dir
     assert config.config_file
     assert config.default_config
 
 
-def test_ensure_config_exists__create():
-    config = ConfigManager()
+def test_ensure_config_exists__create(manager):
     # Create config file if it does not exist
     mock_open_file = mock.mock_open()
     with (
-        patch.object(config, "config_file", new=mock_File(exists=False)),
-        patch.object(config, "config_dir", new=mock_Dir(exists=False)),
+        patch.object(manager, "config_file", new=mock_File(exists=False)),
+        patch.object(manager, "config_dir", new=mock_Dir(exists=False)),
         patch("builtins.open", mock_open_file),
-        patch.object(config, "write_default_config", return_value=None),
+        patch.object(manager, "write_default_config", return_value=None),
     ):
-        config.ensure_config_exists()
+        manager.ensure_config_exists()
         mock_open_file.assert_called_once()
 
 
-def test_ensure_config_exists__exists():
-    config = ConfigManager()
+def test_ensure_config_exists__exists(manager):
     # Create config file if it does not exist
     mock_open_file = mock.mock_open()
     with (
-        patch.object(config, "config_file", new=mock_File(exists=True)),
-        patch.object(config, "config_dir", new=mock_Dir(exists=False)),
+        patch.object(manager, "config_file", new=mock_File(exists=True)),
+        patch.object(manager, "config_dir", new=mock_Dir(exists=False)),
         patch("builtins.open", mock_open_file),
-        patch.object(config, "write_default_config", return_value=None),
+        patch.object(manager, "write_default_config", return_value=None),
     ):
-        config.ensure_config_exists()
+        manager.ensure_config_exists()
         mock_open_file.assert_not_called()
 
 
-def test_write_default_config():
-    config = ConfigManager()
+def test_write_default_config(manager):
     mock_file = mock.mock_open()
     with mock_file() as file:
-        config.write_default_config(file)
+        manager.write_default_config(file)
         file.write.assert_called()
 
 
-def test_load_config__exists():
+def test_load_config__exists(manager):
     toml_data = {
         "name": "MyApp",
         "version": "1.0",
@@ -85,111 +94,102 @@ def test_load_config__exists():
         "builtins.open", mock.mock_open(read_data=b'name = "MyApp"\nversion = "1.0"')
     ):
         with mock.patch("tomllib.load", return_value=toml_data):
-            config_loader = ConfigManager()
-            config_loader.config_file = mock_config_file
-            config = config_loader.load_config()
+            manager.config_file = mock_config_file
+            config = manager.load_config()
             assert config == toml_data
 
 
-def test_load_config__not_exists():
+def test_load_config__not_exists(manager):
     mock_config_file = mock.Mock()
     mock_config_file.exists.return_value = False
-    config_loader = ConfigManager()
-    config_loader.config_file = mock_config_file
-    config = config_loader.load_config()
+    manager.config_file = mock_config_file
+    config = manager.load_config()
     assert config == {}
 
 
-def test_merge_configs(): ...
+def test_merge_configs():
+    pass
 
 
-def test_load_and_merge_config(): ...
+def test_load_and_merge_config():
+    pass
 
 
-def test_get_project_folder(): ...
+def test_get_project_folder():
+    pass
 
 
-def test_get_default_project(): ...
+def test_get_default_project():
+    pass
 
 
-def test_get_simple_key():
-    manager = ConfigManager()
+def test_get_simple_key(manager):
     manager.config = {"name": "Alice"}
     assert manager.get("name", None) == "Alice"
 
 
-def test_get_missing_key():
-    manager = ConfigManager()
+def test_get_missing_key(manager):
     manager.config = {"name": "Alice"}
     assert not manager.get("age", None)
 
 
-def test_get_nested_key():
-    manager = ConfigManager()
+def test_get_nested_key(manager):
     manager.config = {"person": {"name": "Bob"}}
     assert manager.get("person.name", None) == "Bob"
 
 
-def test_get_deeply_nested_key():
-    manager = ConfigManager()
+def test_get_deeply_nested_key(manager):
     manager.config = {"a": {"b": {"c": {"d": {"e": "value"}}}}}
     assert manager.get("a.b.c.d.e", None) == "value"
 
 
-def test_get_deeply_nested_missing_key():
-    manager = ConfigManager()
+def test_get_deeply_nested_missing_key(manager):
     manager.config = {"a": {"b": {"c": {"d": {"e": "value"}}}}}
     assert not manager.get("a.b.d.e", None)
 
 
-def test_get_default_value():
-    manager = ConfigManager()
+def test_get_default_value(manager):
     manager.config = {"name": "Alice"}
     assert manager.get("age", 30) == 30
 
 
-def test_set_simple_key():
-    manager = ConfigManager()
+def test_set_simple_key(manager):
     manager.set("name", "Alice")
     assert manager.config.get("name", None) == "Alice"
 
 
-def test_set_nested_key():
-    manager = ConfigManager()
+def test_set_nested_key(manager):
     manager.set("person.name", "Bob")
     assert manager.config.get("person", None) == {"name": "Bob"}
+    assert manager.config.get("person", {}).get("name", None) == "Bob"
 
 
-def test_set_overwrite_key():
-    manager = ConfigManager()
+def test_set_overwrite_key(manager):
     manager.set("name", "Alice")
     manager.set("name", "Charlie")
     assert manager.config.get("name", None) == "Charlie"
 
 
-def test_set_add_to_existing_nested_key():
-    manager = ConfigManager()
+def test_set_add_to_existing_nested_key(manager):
     manager.set("person.name", "Bob")
     manager.set("person.age", 30)
     assert manager.config.get("person", None) == {"name": "Bob", "age": 30}
 
 
-def test_set_deeply_nested_key():
-    manager = ConfigManager()
+def test_set_deeply_nested_key(manager):
     manager.set("a.b.c.d.e", "value")
     assert manager.config.get("a", None) == {"b": {"c": {"d": {"e": "value"}}}}
 
 
-def test_save():
+def test_save(manager):
     config = {"name": "MyApp", "version": "1.0"}
     mock_open = mock.mock_open()
-    config_manager = ConfigManager()
-    config_manager.config_file = "dummy_file.toml"
-    config_manager.config = config
+    manager.config_file = "dummy_file.toml"
+    manager.config = config
     with (
         mock.patch("builtins.open", mock_open),
         mock.patch("tomli_w.dump") as mock_tomli_w_dump,
     ):
-        config_manager.save()
+        manager.save()
         mock_open.assert_called_once_with("dummy_file.toml", "wb")
         mock_tomli_w_dump.assert_called_once_with(config, mock_open())

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -112,6 +112,42 @@ def test_get_project_folder(): ...
 def test_get_default_project(): ...
 
 
+def test_get_simple_key():
+    manager = ConfigManager()
+    manager.config = {"name": "Alice"}
+    assert manager.get("name", None) == "Alice"
+
+
+def test_get_missing_key():
+    manager = ConfigManager()
+    manager.config = {"name": "Alice"}
+    assert not manager.get("age", None)
+
+
+def test_get_nested_key():
+    manager = ConfigManager()
+    manager.config = {"person": {"name": "Bob"}}
+    assert manager.get("person.name", None) == "Bob"
+
+
+def test_get_deeply_nested_key():
+    manager = ConfigManager()
+    manager.config = {"a": {"b": {"c": {"d": {"e": "value"}}}}}
+    assert manager.get("a.b.c.d.e", None) == "value"
+
+
+def test_get_deeply_nested_missing_key():
+    manager = ConfigManager()
+    manager.config = {"a": {"b": {"c": {"d": {"e": "value"}}}}}
+    assert not manager.get("a.b.d.e", None)
+
+
+def test_get_default_value():
+    manager = ConfigManager()
+    manager.config = {"name": "Alice"}
+    assert manager.get("age", 30) == 30
+
+
 def test_set_simple_key():
     manager = ConfigManager()
     manager.set("name", "Alice")

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -66,14 +66,22 @@ def test_get_custom_assets_folder__not_exists():
 
 @pytest.fixture
 def project():
-    with patch(
-        "InsightBoard.project.project.get_projects_folder"
-    ) as mock_projects_folder:
+    path_exists = Path.exists  # Rename to prevent recursive calls
+
+    # Mock existence of the project folder
+    def mock_path_exists(self):
+        if self.name == "project_name":
+            return True
+        return path_exists(self)
+
+    with (
+        patch(
+            "InsightBoard.project.project.get_projects_folder"
+        ) as mock_projects_folder,
+        patch("pathlib.Path.exists", new=mock_path_exists),
+    ):
         mock_projects_folder.return_value = "/projects"
-        with patch("InsightBoard.project.project.Path") as mock_path:
-            mock_path.return_value = mock_Path("/projects/project_name")
-            mock_path.exists.return_value = True
-            project = Project("project_name")
+        project = Project("project_name")
     return project
 
 

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -72,6 +72,7 @@ def project():
         mock_projects_folder.return_value = "/projects"
         with patch("InsightBoard.project.project.Path") as mock_path:
             mock_path.return_value = mock_Path("/projects/project_name")
+            mock_path.exists.return_value = True
             project = Project("project_name")
     return project
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -42,8 +42,15 @@ def sample_schema():
 def test_get_project():
     # Get an existing project
     name = "test_project"
-    with patch("pathlib.Path.exists") as mock_path_exists:
-        mock_path_exists.return_value = True
+    path_exists = Path.exists  # Rename to prevent recursive calls
+
+    # Mock existence of the project folder
+    def mock_path_exists(self):
+        if self.name == "test_project":
+            return True
+        return path_exists(self)
+
+    with patch("pathlib.Path.exists", new=mock_path_exists):
         project = get_project(name)
     assert isinstance(project, Project)
     assert project.name == name

--- a/uv.lock
+++ b/uv.lock
@@ -216,6 +216,20 @@ wheels = [
 ]
 
 [[package]]
+name = "dash-bootstrap-templates"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dash" },
+    { name = "dash-bootstrap-components" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/a6/40a3db87c1366c278a678ce2a17d5fb2390dcfe22ab0659f3e9f5d6dc1a4/dash_bootstrap_templates-1.2.4.tar.gz", hash = "sha256:7e15f45fcc17a8ac4ba49a261c9168476330f6a835adeb261b06c7c5f434baa6", size = 110530 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/63/cbe79614edefaaf09dff3576a1fea7173b2d52620502d3b2607d36ae2609/dash_bootstrap_templates-1.2.4-py3-none-any.whl", hash = "sha256:8a794b6bbc2d5e820087417d17f8d110928a64be12fb21e829b15413de43a0aa", size = 97228 },
+]
+
+[[package]]
 name = "dash-core-components"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -314,12 +328,13 @@ wheels = [
 
 [[package]]
 name = "insightboard"
-version = "0.0.1.dev72+gf891980.d20241011"
+version = "0.0.1.dev74+ga1a3248.d20241016"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
     { name = "dash" },
     { name = "dash-bootstrap-components" },
+    { name = "dash-bootstrap-templates" },
     { name = "dash-dangerously-set-inner-html" },
     { name = "dash-table" },
     { name = "jsonschema" },
@@ -343,6 +358,7 @@ requires-dist = [
     { name = "cachetools", specifier = ">=5.5.0" },
     { name = "dash", specifier = ">=2.18.1" },
     { name = "dash-bootstrap-components", specifier = ">=1.6.0" },
+    { name = "dash-bootstrap-templates", specifier = ">=1.2.4" },
     { name = "dash-dangerously-set-inner-html", specifier = ">=0.0.2" },
     { name = "dash-table", specifier = ">=5.0.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },


### PR DESCRIPTION
- Move global configuration to ~/.config (or AppData on Windows)
- Provide per-project configuration files
- Add meta-data to parquet files (principally a database version number)
- Add user-configurable global / system settings:
  - projects path
  - dark mode
- Add user-configurable project settings
  - database backend selection (flat file parquet versioned or unversioned)
  - backup policy
- Add support and tests for a versioned parquet database

Versioned parquet needs to be enabled in settings and saves to a different file than unversioned parquet (which remains the default at this time).