### PR TITLE
Remove chromedriver-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ build-backend = "setuptools.build_meta"
 [tool.uv]
 package = true
 dev-dependencies = [
-    "chromedriver-py>=129.0.6668.89",
     "pytest-cov>=5.0.0",
     "pytest>=8.3.3",
     "selenium>=4.25.0",

--- a/tests/system/utils.py
+++ b/tests/system/utils.py
@@ -12,12 +12,11 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from chromedriver_py import binary_path
 
 
 def chromedriver_present():
     try:
-        Service(binary_path)
+        Service()
     except Exception:
         return False
     return True
@@ -41,7 +40,7 @@ def timeout(driver, fcn):
 
 @pytest.fixture
 def driver():
-    service = Service(binary_path)
+    service = Service()
     options = webdriver.ChromeOptions()
     options.add_argument("--headless")
     options.add_argument("--window-size=1920,1080")

--- a/uv.lock
+++ b/uv.lock
@@ -113,15 +113,6 @@ wheels = [
 ]
 
 [[package]]
-name = "chromedriver-py"
-version = "129.0.6668.100"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/96/44ade5c70ec4661d9ac0ef29d77eca8345100da9b77938b59860df1e0fd9/chromedriver_py-129.0.6668.100.tar.gz", hash = "sha256:e82e83d172968e603df59b6c024df097c8b2e69badb87c2128c8f1bc45883a12", size = 44138371 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/2d/9c1498a0b0bd27f1c63de5c41a9003a7bec23c9002856f05cb04ba4caeb5/chromedriver_py-129.0.6668.100-py3-none-any.whl", hash = "sha256:f99388b81feabefaf0bc1a984bab630f66ea87c29ad3ca163461a78d57d3585d", size = 44234462 },
-]
-
-[[package]]
 name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
@@ -375,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "insightboard"
-version = "0.0.1.dev88+g82511a2.d20241028"
+version = "0.0.1.dev89+g40dbc6d.d20241204"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
@@ -399,7 +390,6 @@ duckdb = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "chromedriver-py" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "selenium" },
@@ -424,7 +414,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "chromedriver-py", specifier = ">=129.0.6668.89" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "selenium", specifier = ">=4.25.0" },


### PR DESCRIPTION
- `chromedriver-py` installs the latest chromedriver version, which is not always compatible with the version available on the system (used for testing). Remove `chromedriver-py` dev dependency.